### PR TITLE
downgrade luarocks to 2.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM openshift/base-centos7
 MAINTAINER 3scale <operations@3scale.net>
 
 ARG OPENRESTY_RPM_VERSION="1.11.2.1-3.el7.centos"
-ARG LUAROCKS_VERSION="2.4.0"
+ARG LUAROCKS_VERSION="2.3.0"
 ENV AUTO_UPDATE_INTERVAL=0 BUILDER_VERSION=0.1
 
 LABEL io.k8s.description="Platform for building openresty" \


### PR DESCRIPTION
2.4.0 raises exception when running busted with openresty

> attempt to yield across C-call boundary

https://travis-ci.org/3scale/docker-gateway/builds/163398140

opened issue on luarocks: https://github.com/keplerproject/luarocks/issues/620
