### PR TITLE
[runtime] use runtime image as builder image

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -27,7 +27,14 @@ cp -Rf /tmp/src/. ./
 echo "---> Building application from source..."
 
 cd /opt/app
-cp /tmp/src/*.rockspec /opt/app/
-luarocks make *.rockspec --tree=/usr/local/openresty/luajit
 
-ln -svf "$(pwd)/bin" "${HOME}"
+if compgen -G "/tmp/src/*.rockspec" > /dev/null; then
+  cp /tmp/src/*.rockspec /opt/app/
+  luarocks make ./*.rockspec --tree=/usr/local/openresty/luajit
+
+fi
+
+if [ ! -e "$(pwd)/bin" ];
+then
+  ln -svf "$(pwd)/bin" "${HOME}"
+fi

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -43,7 +43,8 @@ COPY ./.s2i/bin/assemble* /usr/libexec/s2i/
 
 #TODO: Drop the root user and make the content of /opt/app owned by user 1001
 RUN mkdir -p "${HOME}/logs" "${HOME}/http.d" && \
-    chmod g+w "${HOME}" "${HOME}"/* "${HOME}/http.d"
+    chmod g+w "${HOME}" "${HOME}"/* "${HOME}/http.d" && \
+    ln -s /opt/app-root/scripts/run /usr/libexec/s2i/
 
 # This default user is created in the openshift/base-centos7 image
 USER 1001

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -26,7 +26,8 @@ RUN mkdir -p "${HOME}" && \
     ln -s /dev/stderr /opt/app-root/src/logs/error.log && \
     mkdir -p /usr/local/share/lua/ && \
     chmod g+w /usr/local/share/lua/ && \
-    chown -R 1001:0 /opt/app-root /usr/local/share/lua/
+    chown -R 1001:0 /opt/app-root /usr/local/share/lua/ && \
+    ln -s /opt/app-root/app /opt/app
 
 LABEL \
       # Location of the STI scripts inside the image.
@@ -38,7 +39,7 @@ LABEL \
       io.openshift.tags="builder,s2i,openresty"
 
 COPY bin/ /usr/bin/
-COPY ./.s2i/bin/assemble-runtime /usr/libexec/s2i/
+COPY ./.s2i/bin/assemble* /usr/libexec/s2i/
 
 #TODO: Drop the root user and make the content of /opt/app owned by user 1001
 RUN mkdir -p "${HOME}/logs" "${HOME}/http.d" && \

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@ IMAGE_NAME ?= s2i-openresty-centos7
 FORCE_PULL ?= --pull
 REGISTRY ?= quay.io/3scale
 
-build:
+build: ## Build builder image
 	docker build $(FORCE_PULL) --tag $(IMAGE_NAME) .
 
-build-runtime:
+build-runtime: ## Build runtime image
 	docker build $(FORCE_PULL) --tag $(IMAGE_NAME)-runtime -f Dockerfile.runtime .
 
 .PHONY: test test/test-app
@@ -14,19 +14,25 @@ test/test-app:
 	git submodule update --init --recursive $@
 	rm "$@/.git"
 	ln -sfv ../../.git/modules/$@ "$@/.git"
-bash:
+bash: ## Run bash in built builder image
 	docker run -it --user root $(IMAGE_NAME) bash
 
-push:
+push: ## Tag and push the builder image to the docker registry
 	docker tag $(IMAGE_NAME) $(REGISTRY)/$(IMAGE_NAME)
 	docker push $(REGISTRY)/$(IMAGE_NAME)
 
-push-runtime:
+push-runtime: ## Tag and push the runtime iamge to the docker registry
 	docker tag $(IMAGE_NAME)-runtime $(REGISTRY)/$(IMAGE_NAME)-runtime
 	docker push $(REGISTRY)/$(IMAGE_NAME)-runtime
 
+test: ## Run tests
 test: test-build test/test-app
 	test/run
 
+test-build: ## Test just building the images
 test-build: export IMAGE_NAME := $(IMAGE_NAME)-candidate
 test-build: build build-runtime
+
+# Check http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+help: ## Print this help
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)


### PR DESCRIPTION
so you can stack more files on top of the runtime image

useful for adding customization files