### PR TITLE
install openresty-openssl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN yum clean all -y \
  && yum install -y \
         openresty-${OPENRESTY_RPM_VERSION} \
         openresty-resty-${OPENRESTY_RPM_VERSION} \
+        openresty-openssl \
     && echo "Cleaning all dependencies" \
     && yum clean all -y \
     && mkdir -p /opt/app/logs \

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -17,7 +17,8 @@ RUN mkdir -p "${HOME}" && \
     rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
     yum install -y bind-utils tar dnsmasq && \
     yum install -y openresty-${OPENRESTY_RPM_VERSION} \
-                   openresty-resty-${OPENRESTY_RPM_VERSION} && \
+                   openresty-resty-${OPENRESTY_RPM_VERSION} \
+                   openresty-openssl && \
     yum clean all -y && \
     mkdir /opt/app-root/src/logs && \
     rm -r /usr/local/openresty/nginx/logs && \


### PR DESCRIPTION
so we get OpenSSL 1.0.2 (for https://github.com/3scale/apicast/issues/320#issuecomment-288641363)

as  https://openresty.org/en/rpm-packages.html#openresty-openssl says this allows people to use `ssl_*_by_lua` functions. Without this version of OpenSSL OpenResty can't really dynamically terminate SSL. We might wait with this after CR1.

would @3scale/productization be ok with this?