### PR TITLE
push ca-bundle.crt into the conf directory

### DIFF
--- a/.s2i/bin/assemble-runtime
+++ b/.s2i/bin/assemble-runtime
@@ -19,3 +19,4 @@ ln --verbose --symbolic "$(pwd)/share/lua/"* /usr/local/share/lua/
 cp --verbose --recursive --no-target-directory --no-clobber "$(pwd)/app" "$(pwd)/src"
 ln --verbose --symbolic "$(pwd)/src/bin" "$(pwd)/bin"
 ln --verbose --symbolic "$(pwd)/src/http.d" "$(pwd)"
+ln --verbose --symbolic --force /etc/ssl/certs/ca-bundle.crt "$(pwd)/src/conf"

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,11 +29,12 @@ RUN yum clean all -y \
         openresty-openssl \
     && echo "Cleaning all dependencies" \
     && yum clean all -y \
-    && mkdir -p /opt/app/logs \
+    && mkdir -p /opt/app/logs /opt/app/conf \
     && rmdir /usr/local/openresty/nginx/logs \
     && ln -s /opt/app/logs /usr/local/openresty/nginx/logs \
     && ln -sf /dev/stdout /opt/app/logs/access.log \
-    && ln -sf /dev/stderr /opt/app/logs/error.log
+    && ln -sf /dev/stderr /opt/app/logs/error.log \
+    && ln -s /etc/ssl/certs/ca-bundle.crt /opt/app/conf
 
 # TODO (optional): Copy the builder files into /opt/app
 # COPY ./<builder_folder>/ /opt/app/


### PR DESCRIPTION
so both locally and in docker you can expect ca-bundle on the same path

ensures the `<APICAST_DIR>/conf/ca-bundle.crt` is a symlink and points to `/etc/ssl/certs/ca-bundle.crt`.
The file can be there and should be overridden (apicast has it in .s2iignore to not copy it into the image).