### PR TITLE
build openresty 1.11.2.3-1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM openshift/base-centos7
 MAINTAINER 3scale <operations@3scale.net>
 
-ARG OPENRESTY_RPM_VERSION="1.11.2.2-8.el7.centos"
+ARG OPENRESTY_RPM_VERSION="1.11.2.3"
 ARG LUAROCKS_VERSION="2.3.0"
 ENV AUTO_UPDATE_INTERVAL=0 BUILDER_VERSION=0.1
 
@@ -30,7 +30,7 @@ RUN yum clean all -y \
     && echo "Cleaning all dependencies" \
     && yum clean all -y \
     && mkdir -p /opt/app/logs /opt/app/conf \
-    && rmdir /usr/local/openresty/nginx/logs \
+    && mkdir -p /usr/local/openresty/nginx \
     && ln -s /opt/app/logs /usr/local/openresty/nginx/logs \
     && ln -sf /dev/stdout /opt/app/logs/access.log \
     && ln -sf /dev/stderr /opt/app/logs/error.log \

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -2,7 +2,7 @@
 FROM centos:centos7
 MAINTAINER 3scale <operations@3scale.net>
 
-ARG OPENRESTY_RPM_VERSION="1.11.2.2-8.el7.centos"
+ARG OPENRESTY_RPM_VERSION="1.11.2.3"
 
 ENV \
     BUILDER_VERSION=0.1 \
@@ -21,7 +21,7 @@ RUN mkdir -p "${HOME}" && \
                    openresty-openssl && \
     yum clean all -y && \
     mkdir /opt/app-root/src/logs && \
-    rm -r /usr/local/openresty/nginx/logs && \
+    mkdir -p /usr/local/openresty/nginx && \
     ln -s /opt/app-root/src/logs /usr/local/openresty/nginx/logs && \
     ln -s /dev/stdout /opt/app-root/src/logs/access.log && \
     ln -s /dev/stderr /opt/app-root/src/logs/error.log && \


### PR DESCRIPTION
https://openresty.org/en/changelog-1011002.html#version-1.11.2.3---21-april-2017

/cc @3scale/productization new OpenResty version , looks like it does not create logs folder by default

older packages are no longer available, so we have to build this one