### PR TITLE
set correct permissions in nginx prefix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,8 @@ RUN mkdir -p -v /opt/app/logs /opt/app/http.d /usr/local/openresty/luajit/lib/lu
 		 /usr/local/openresty/luajit \
                  /usr/local/openresty/luajit/lib/luarocks \
 		 /usr/local/openresty/luajit/bin/ \
+		 /usr/local/openresty/nginx/ \
+		 /usr/local/openresty/nginx/logs/ \
 		 "${HOME}/.cache"
 
 # This default user is created in the openshift/base-centos7 image

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -27,7 +27,9 @@ RUN mkdir -p "${HOME}" && \
     ln -s /dev/stderr /opt/app-root/src/logs/error.log && \
     mkdir -p /usr/local/share/lua/ && \
     chmod g+w /usr/local/share/lua/ && \
-    chown -R 1001:0 /opt/app-root /usr/local/share/lua/ && \
+    chown -R 1001:0 /opt/app-root /usr/local/share/lua/ \
+		 /usr/local/openresty/nginx/ \
+		 /usr/local/openresty/nginx/logs/ && \
     ln -s /opt/app-root/app /opt/app
 
 LABEL \


### PR DESCRIPTION
so nginx can start with default prefix configuration