### PR TITLE
drop luarocks in favour of rover

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -17,7 +17,7 @@ fi
 #
 if [ "$(ls /tmp/artifacts/ 2>/dev/null)" ]; then
   echo "---> Restoring build artifacts..."
-  cp -vr /tmp/artifacts/. /usr/local/openresty/luajit/
+  cp -vr /tmp/artifacts/. .
   rm -rf /tmp/artifacts/
 fi
 
@@ -26,14 +26,9 @@ cp -Rf /tmp/src/. ./
 
 echo "---> Building application from source..."
 
-cd /opt/app
+export PATH="/usr/local/openresty/luajit/bin/:${PATH}"
 
-if compgen -G "/tmp/src/*.rockspec" > /dev/null; then
-  cp /tmp/src/*.rockspec /opt/app/
-  find . -name "*.rockspec" -exec luarocks ${LUAROCKS_INSTALL:-make} {} \;
-fi
-
-if [ ! -e "$(pwd)/bin" ];
-then
-  ln -svf "$(pwd)/bin" "${HOME}"
+if [ -e "/tmp/src/Roverfile.lock" ]; then
+  echo "---> Installing dependencies"
+  rover install --roverfile /tmp/src/Roverfile --path .
 fi

--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -32,3 +32,5 @@ if [ -e "/tmp/src/Roverfile.lock" ]; then
   echo "---> Installing dependencies"
   rover install --roverfile /tmp/src/Roverfile --path .
 fi
+
+ln --verbose --symbolic /etc/ssl/certs/ca-bundle.crt "$(pwd)/conf" || true

--- a/.s2i/bin/assemble-runtime
+++ b/.s2i/bin/assemble-runtime
@@ -14,9 +14,3 @@ if [[ "$1" == "-h" ]]; then
 fi
 
 echo "---> Copying runtime artifacts"
-
-ln --verbose --symbolic "$(pwd)/share/lua/"* /usr/local/share/lua/
-cp --verbose --recursive --no-target-directory --no-clobber "$(pwd)/app" "$(pwd)/src"
-ln --verbose --symbolic "$(pwd)/src/bin" "$(pwd)/bin"
-ln --verbose --symbolic "$(pwd)/src/http.d" "$(pwd)"
-ln --verbose --symbolic --force /etc/ssl/certs/ca-bundle.crt "$(pwd)/src/conf"

--- a/.s2i/bin/run
+++ b/.s2i/bin/run
@@ -3,5 +3,5 @@
 if [ -f /tmp/scripts/run ]; then 
 	exec /tmp/scripts/run "$@"
 else
-	exec openresty -p /opt/app
+	exec openresty -c "$(pwd)/conf/nginx.conf" -g "daemon off; error_log stderr ${LOG_LEVEL:=warn};";
 fi

--- a/.s2i/bin/save-artifacts
+++ b/.s2i/bin/save-artifacts
@@ -8,4 +8,4 @@
 #	https://github.com/openshift/source-to-image/blob/master/docs/builder_image.md
 #
 
-tar -cf - --directory=/usr/local/openresty/luajit lib/luarocks lib64/luarocks share/lua/5.1
+tar -cf - --directory=/opt/app-root/src lua_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,6 @@ RUN yum clean all -y \
 # COPY ./<builder_folder>/ /opt/app/
 
 COPY config-*.lua /etc/luarocks/
-# override entrypoint to always setup luarocks paths
-RUN ln -sf /usr/libexec/s2i/entrypoint /usr/local/bin/container-entrypoint
 
 RUN \
   yum install -y luarocks && \
@@ -44,6 +42,11 @@ RUN \
   chmod g+w "${HOME}/.cache" && \
   rm -rf /var/cache/yum && yum clean all -y && \
   rm -rf "${HOME}/.cache/luarocks" ./*
+
+# override entrypoint to always setup luarocks paths
+RUN ln -sf /usr/libexec/s2i/entrypoint /usr/local/bin/container-entrypoint && \
+ openresty -t && openresty-debug -t && \
+ chmod -vR g+w /usr/local/openresty{,-*}/nginx/{*_temp,logs}
 
 COPY ./.s2i/bin/ /usr/libexec/s2i
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ FROM openshift/base-centos7
 
 ARG OPENRESTY_RPM_VERSION="1.11.2.5"
 ARG LUAROCKS_VERSION="2.3.0"
-ENV AUTO_UPDATE_INTERVAL=0 BUILDER_VERSION=0.1
 
 LABEL io.k8s.description="Platform for building openresty" \
       io.k8s.display-name="s2i Openresty centos 7 - ${OPENRESTY_RPM_VERSION}" \
@@ -18,10 +17,8 @@ RUN yum clean all -y \
  && yum install -y epel-release \
  && yum upgrade -y \
  && yum install -y \
-        luarocks \
-        bind-utils \ 
         perl-Test-Nginx perl-JSON-WebToken \
-	perl-TAP-Harness-JUnit \
+        perl-TAP-Harness-JUnit \
         dnsmasq \
  && yum install -y \
         openresty-${OPENRESTY_RPM_VERSION} \
@@ -29,42 +26,34 @@ RUN yum clean all -y \
         openresty-debug-${OPENRESTY_RPM_VERSION} \
         openresty-openssl \
     && echo "Cleaning all dependencies" \
-    && yum clean all -y \
-    && mkdir -p /opt/app/logs /opt/app/conf \
-    && mkdir -p /usr/local/openresty/nginx \
-    && ln -s /opt/app/logs /usr/local/openresty/nginx/logs \
-    && ln -sf /dev/stdout /opt/app/logs/access.log \
-    && ln -sf /dev/stderr /opt/app/logs/error.log \
-    && ln -s /etc/ssl/certs/ca-bundle.crt /opt/app/conf
+    && yum clean all -y
 
 # TODO (optional): Copy the builder files into /opt/app
 # COPY ./<builder_folder>/ /opt/app/
 
-COPY ./.s2i/bin/ /usr/libexec/s2i
 COPY config-*.lua /etc/luarocks/
-ENV LUA_PATH=";;/usr/lib64/lua/5.1/?.lua" LUAROCKS_INSTALL=make
-
 # override entrypoint to always setup luarocks paths
-RUN ln -sf /usr/libexec/s2i/entrypoint /usr/local/bin/container-entrypoint \
-    && ln -s /usr/lib64/lua/5.1/luarocks /usr/share/lua/5.1/luarocks
+RUN ln -sf /usr/libexec/s2i/entrypoint /usr/local/bin/container-entrypoint
 
-#TODO: Drop the root user and make the content of /opt/app owned by user 1001
-RUN mkdir -p -v /opt/app/logs /opt/app/http.d /usr/local/openresty/luajit/lib/luarocks "${HOME}/.cache" \
- && chmod -v g+w /opt/app /opt/app/* \
-                 /usr/local/openresty/luajit/share/lua/5.1 \
-		 /usr/local/openresty/luajit/lib/lua/5.1 \
-		 /usr/local/openresty/luajit \
-                 /usr/local/openresty/luajit/lib/luarocks \
-		 /usr/local/openresty/luajit/bin/ \
-		 /usr/local/openresty/nginx/ \
-		 /usr/local/openresty/nginx/logs/ \
-		 "${HOME}/.cache"
+RUN \
+  yum install -y luarocks && \
+  ln -s /usr/lib64/lua/5.1/luarocks /usr/share/lua/5.1/luarocks && \
+  luarocks install --server=http://luarocks.org/dev lua-rover && \
+  yum -y remove luarocks && \
+  mv /etc/luarocks/config-5.1.lua{.rpmsave,} && \
+  chmod g+w "${HOME}/.cache" && \
+  rm -rf /var/cache/yum && yum clean all -y && \
+  rm -rf "${HOME}/.cache/luarocks" ./*
+
+COPY ./.s2i/bin/ /usr/libexec/s2i
 
 # This default user is created in the openshift/base-centos7 image
 USER 1001
 
-RUN luarocks install --server=http://luarocks.org/dev lua-rover # 1
+ENV PATH="./lua_modules/bin:${PATH}" \
+ LUA_PATH="./lua_modules/share/lua/5.1/?.lua;./lua_modules/share/lua/5.1/?/init.lua;;" \
+ LUA_CPATH="./lua_modules/lib/lua/5.1/?.so;;"
 
-WORKDIR /opt/app/
+WORKDIR ${HOME}
 EXPOSE 8080
 CMD ["usage"]

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -3,10 +3,7 @@ FROM centos:centos7
 
 ARG OPENRESTY_RPM_VERSION="1.11.2.5"
 
-ENV \
-    BUILDER_VERSION=0.1 \
-    # The $HOME is not set by default, but some applications needs this variable
-    HOME=/opt/app-root/src \
+ENV HOME=/opt/app-root/src \
     PATH=/opt/app-root/src/bin:/opt/app-root/bin:$PATH
 
 RUN mkdir -p "${HOME}" && \
@@ -14,39 +11,23 @@ RUN mkdir -p "${HOME}" && \
           -c "Default Application User" default && \
     yum-config-manager --add-repo https://openresty.org/yum/centos/OpenResty.repo && \
     rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
-    yum install -y bind-utils tar dnsmasq && \
+    yum install -y tar dnsmasq && \
     yum install -y openresty-${OPENRESTY_RPM_VERSION} \
                    openresty-resty-${OPENRESTY_RPM_VERSION} \
                    openresty-openssl && \
-    yum clean all -y && \
-    mkdir /opt/app-root/src/logs && \
-    mkdir -p /usr/local/openresty/nginx && \
-    ln -s /opt/app-root/src/logs /usr/local/openresty/nginx/logs && \
-    ln -s /dev/stdout /opt/app-root/src/logs/access.log && \
-    ln -s /dev/stderr /opt/app-root/src/logs/error.log && \
-    mkdir -p /usr/local/share/lua/ && \
-    chmod g+w /usr/local/share/lua/ && \
-    chown -R 1001:0 /opt/app-root /usr/local/share/lua/ \
-		 /usr/local/openresty/nginx/ \
-		 /usr/local/openresty/nginx/logs/ && \
-    ln -s /opt/app-root/app /opt/app
+    yum clean all
 
-LABEL \
-      # Location of the STI scripts inside the image.
-      io.openshift.s2i.scripts-url=image:///usr/libexec/s2i \
+LABEL io.openshift.s2i.scripts-url=image:///usr/libexec/s2i \
       io.k8s.description="Platform for building openresty" \
       io.k8s.display-name="s2i Openresty centos 7 - ${OPENRESTY_RPM_VERSION}"\
       io.openshift.expose-services="8080:http" \
-      io.openshift.s2i.assemble-input-files="/usr/local/openresty/luajit/share;/opt/app" \
+      io.openshift.s2i.assemble-input-files="/opt/app-root/src" \
       io.openshift.tags="builder,s2i,openresty"
 
 COPY bin/ /usr/bin/
 COPY ./.s2i/bin/assemble* /usr/libexec/s2i/
 
-#TODO: Drop the root user and make the content of /opt/app owned by user 1001
-RUN mkdir -p "${HOME}/logs" "${HOME}/http.d" && \
-    chmod g+w "${HOME}" "${HOME}"/* "${HOME}/http.d" && \
-    ln -s /opt/app-root/scripts/run /usr/libexec/s2i/
+RUN ln -s /opt/app-root/src/scripts/run /usr/libexec/s2i/
 
 # This default user is created in the openshift/base-centos7 image
 USER 1001
@@ -54,6 +35,10 @@ USER 1001
 EXPOSE 8080
 
 WORKDIR /opt/app-root
+
+ENV PATH="./lua_modules/bin:${PATH}" \
+ LUA_PATH="./lua_modules/share/lua/5.1/?.lua;./lua_modules/share/lua/5.1/?/init.lua;;" \
+ LUA_CPATH="./lua_modules/lib/lua/5.1/?.so;;"
 
 ENTRYPOINT ["container-entrypoint"]
 CMD ["/usr/libexec/s2i/usage"]

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -27,7 +27,9 @@ LABEL io.openshift.s2i.scripts-url=image:///usr/libexec/s2i \
 COPY bin/ /usr/bin/
 COPY ./.s2i/bin/assemble* /usr/libexec/s2i/
 
-RUN ln -s /opt/app-root/src/scripts/run /usr/libexec/s2i/
+RUN ln -vs /opt/app-root/src/scripts/run /usr/libexec/s2i/ && \
+ openresty -t && \
+ chmod -vR g+w /usr/local/openresty/nginx/{*_temp,logs}
 
 # This default user is created in the openshift/base-centos7 image
 USER 1001

--- a/bin/container-entrypoint
+++ b/bin/container-entrypoint
@@ -1,2 +1,16 @@
 #!/bin/bash
-exec "$@"
+set -euo pipefail
+IFS=$'\n\t'
+
+# s2i sets the default command to scripts/run.
+# Changing a directory would break that relative path.
+# So lets resolve it before changing the directory and use the absolute path.
+
+args=("$@")
+cmd="$(readlink -e "${args[0]}")" || true
+
+args[0]="${cmd:-${args[0]}}"
+
+cd "${HOME}" # change to home directory
+
+exec "${args[@]}"

--- a/test/run
+++ b/test/run
@@ -173,7 +173,7 @@ test_config() {
   local cid=$1
   echo "Testing nginx config ..."
 
-  test=$(docker exec $(cat ${cid}) container-entrypoint openresty -p . -t)
+  test=$(docker exec $(cat ${cid}) container-entrypoint bin/apicast --test)
 
   return $?
 }


### PR DESCRIPTION
needed for https://github.com/3scale/apicast/pull/449, builds on #37

applications should have proper ENV that contains rover dependencies
also no need to install dependencies from rockspecs when rover lock is there

this PR drops luarocks binary in favour of rover, so it won't automatically install dependencies from rockspecs anymore

also unify the source path on `/opt/app-root/src` as other s2i builders.