### PR TITLE
fix running runtime image without a command

### DIFF
--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -27,7 +27,7 @@ LABEL io.openshift.s2i.scripts-url=image:///usr/libexec/s2i \
 COPY bin/ /usr/bin/
 COPY ./.s2i/bin/assemble* /usr/libexec/s2i/
 
-RUN ln -vs /opt/app-root/src/scripts/run /usr/libexec/s2i/ && \
+RUN ln -vs /opt/app-root/scripts/run /usr/libexec/s2i/ && \
  openresty -t && \
  chmod -vR g+w /usr/local/openresty/nginx/{*_temp,logs}
 

--- a/test/run
+++ b/test/run
@@ -68,6 +68,9 @@ prepare_runtime() {
 }
 
 prepare() {
+  cleanup_image
+  cleanup_runtime_image
+
   if ! image_exists ${IMAGE_NAME}; then
     echo "ERROR: The image ${IMAGE_NAME} must exist before this script is executed."
     exit 1
@@ -99,6 +102,9 @@ cleanup() {
       docker stop $(cat $cid_file)
     fi
   fi
+}
+
+cleanup_image() {
   if image_exists ${IMAGE_NAME}-testapp; then
     docker rmi ${IMAGE_NAME}-testapp
   fi
@@ -110,6 +116,9 @@ cleanup_runtime() {
       docker stop $(cat ${runtime_cid_file})
     fi
   fi
+}
+
+cleanup_runtime_image() {
   if image_exists ${IMAGE_NAME}-runtime-testapp; then
     docker rmi ${IMAGE_NAME}-runtime-testapp
   fi

--- a/test/run
+++ b/test/run
@@ -96,11 +96,19 @@ run_runtime_test_application() {
   docker run --user 100002 --rm --cidfile=${runtime_cid_file} -p ${test_port} --env THREESCALE_PORTAL_ENDPOINT=http://127.0.0.1 ${IMAGE_NAME}-runtime-testapp "$@"
 }
 
+start_runtime_test_application() {
+  cleanup_runtime
+
+  run_runtime_test_application "$@" &
+  wait_for_cid ${runtime_cid_file}
+}
+
 cleanup() {
   if [ -f $cid_file ]; then
     if container_exists; then
       docker stop $(cat $cid_file)
     fi
+    rm "$cid_file"
   fi
 }
 
@@ -115,6 +123,7 @@ cleanup_runtime() {
     if runtime_container_exists; then
       docker stop $(cat ${runtime_cid_file})
     fi
+    rm "${runtime_cid_file}"
   fi
 }
 
@@ -234,14 +243,16 @@ check_result $?
 
 cleanup
 
-run_runtime_test_application &
-
-wait_for_cid ${runtime_cid_file}
+start_runtime_test_application
 
 test_connection ${runtime_cid_file}
 check_result $?
 
 test_top ${runtime_cid_file}
+check_result $?
+
+start_runtime_test_application /usr/libexec/s2i/run
+test_connection ${runtime_cid_file}
 check_result $?
 
 cleanup_runtime


### PR DESCRIPTION
images built from apicast could not be started because 
the Cmd is set to `/usr/libexec/s2i/run` which was 
invalid symlink.