### PR TITLE
Linking acces_log and error_log to stdout/stderr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,9 @@ RUN yum clean all -y \
         openresty-debug-${OPENRESTY_RPM_VERSION} \
         openresty-openssl \
     && echo "Cleaning all dependencies" \
-    && yum clean all -y
+    && yum clean all -y \
+    && ln -sf /dev/stdout /usr/local/openresty/nginx/logs/access.log \
+    && ln -sf /dev/stderr /usr/local/openresty/nginx/logs/error.log
 
 # TODO (optional): Copy the builder files into /opt/app
 # COPY ./<builder_folder>/ /opt/app/

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -15,7 +15,9 @@ RUN mkdir -p "${HOME}" && \
     yum install -y openresty-${OPENRESTY_RPM_VERSION} \
                    openresty-resty-${OPENRESTY_RPM_VERSION} \
                    openresty-openssl && \
-    yum clean all
+    yum clean all && \
+    ln -sf /dev/stdout /usr/local/openresty/nginx/logs/access.log && \
+    ln -sf /dev/stderr /usr/local/openresty/nginx/logs/error.log
 
 LABEL io.openshift.s2i.scripts-url=image:///usr/libexec/s2i \
       io.k8s.description="Platform for building openresty" \


### PR DESCRIPTION
Linkings access and error to do stdout/stderr.

The motivation is to provide those logs on all deployments by default and avoid the need of rotation of logs.