### PR TITLE
[s2i] quiet error message when ca-bundle.crt exists

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -37,4 +37,4 @@ if [ -e "/tmp/src/cpanfile" ]; then
   rm -rf ~/.cpanm
 fi
 
-ln --verbose --symbolic /etc/ssl/certs/ca-bundle.crt "$(pwd)/conf" || true
+ln --verbose --symbolic /etc/ssl/certs/ca-bundle.crt "$(pwd)/conf" 2>/dev/null || true


### PR DESCRIPTION
so it does not confuse people into thinking the build failed