### PR TITLE
fix temp directory permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN \
 # override entrypoint to always setup luarocks paths
 RUN ln -sf /usr/libexec/s2i/entrypoint /usr/local/bin/container-entrypoint && \
  openresty -t && openresty-debug -t && \
- chmod -vR g+w /usr/local/openresty{,-*}/nginx/{*_temp,logs}
+ chmod -vR g+wrX /usr/local/openresty{,-*}/nginx/{*_temp,logs}
 
 COPY ./.s2i/bin/ /usr/libexec/s2i
 

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -31,7 +31,7 @@ COPY ./.s2i/bin/assemble* /usr/libexec/s2i/
 
 RUN ln -vs /opt/app-root/scripts/run /usr/libexec/s2i/ && \
  openresty -t && \
- chmod -vR g+w /usr/local/openresty/nginx/{*_temp,logs}
+ chmod -vR g+wrX /usr/local/openresty/nginx/{*_temp,logs}
 
 # in case someone needs to use rover/luarocks in runtime
 COPY site_config.lua /usr/share/lua/5.1/luarocks/site_config.lua

--- a/test/run
+++ b/test/run
@@ -198,6 +198,15 @@ test_config() {
   return $?
 }
 
+test_temp() {
+  local cid=$1
+  echo "Testing nginx temp directory ..."
+
+  test=$(docker exec --user 1000001 $(cat ${cid}) touch /usr/local/openresty/nginx/client_body_temp/test)
+
+  return $?
+}
+
 test_top() {
   local cid=$1
   local id=$(cat ${cid})
@@ -238,6 +247,9 @@ test_connection ${cid_file}
 check_result $?
 
 test_config ${cid_file}
+check_result $?
+
+test_temp ${cid_file}
 check_result $?
 
 test_top ${cid_file}


### PR DESCRIPTION
`/usr/local/openresty/nginx/client_body_temp/` directory was not writeable