### PR TITLE
[cpanm] skip testing installed dependencies

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -33,7 +33,7 @@ fi
 
 if [ -e "/tmp/src/cpanfile" ]; then
   echo "---> Installing Perl dependencies"
-  cpanm --installdeps /tmp/src
+  cpanm --notest --installdeps /tmp/src
   rm -rf ~/.cpanm
 fi
 


### PR DESCRIPTION
this significanlty improves performance of s2i builds