### PR TITLE
an openshift template to build the two s2i images

### DIFF
--- a/openshift/build-config.yaml
+++ b/openshift/build-config.yaml
@@ -3,10 +3,10 @@ kind: Template
 labels:
 metadata:
   annotations:
-    openshift.io/display-name: APIcast S2I Builder
-  name: apicast-s2i
+    openshift.io/display-name: OpenResty S2I Builder
+  name: s2i-openresty
 parameters:
-- description: The APIcast GIT repository to build.
+- description: The OpenResty S2I GIT repository to use.
   displayName: GIT Repo URL
   name: GIT_REPO
   value: https://github.com/3scale/s2i-openresty.git
@@ -26,7 +26,7 @@ objects:
 - apiVersion: v1
   kind: ImageStream
   metadata:
-    name: apicast-s2i
+    name: s2i-openresty
   spec:
 
 - apiVersion: v1
@@ -46,7 +46,7 @@ objects:
 - apiVersion: v1
   kind: BuildConfig
   metadata:
-    name: apicast-s2i-builder
+    name: s2i-openresty-builder
   spec:
     successfulBuildsHistoryLimit: 1
     failedBuildsHistoryLimit: 1
@@ -54,7 +54,7 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: apicast-s2i:builder
+        name: s2i-openresty:builder
     postCommit: {}
     resources: {}
     runPolicy: Serial
@@ -77,7 +77,7 @@ objects:
 - apiVersion: v1
   kind: BuildConfig
   metadata:
-    name: apicast-s2i-runtime
+    name: s2i-openresty-runtime
   spec:
     successfulBuildsHistoryLimit: 1
     failedBuildsHistoryLimit: 1
@@ -85,7 +85,7 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: apicast-s2i:runtime
+        name: s2i-openresty:runtime
     postCommit: {}
     resources: {}
     runPolicy: Serial

--- a/openshift/build-config.yaml
+++ b/openshift/build-config.yaml
@@ -1,0 +1,106 @@
+apiVersion: v1
+kind: Template
+labels:
+metadata:
+  annotations:
+    openshift.io/display-name: APIcast S2I Builder
+  name: apicast-s2i
+parameters:
+- description: The APIcast GIT repository to build.
+  displayName: GIT Repo URL
+  name: GIT_REPO
+  value: https://github.com/3scale/s2i-openresty.git
+
+- description: The GIT reference (branch/tag) to use.
+  displayName: GIT Reference
+  name: GIT_REF
+  value: master
+
+- description: The base image to use
+  displayName: Base Image
+  name: BASE_IMAGE
+  value: openshift/base-centos7
+
+objects:
+
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: apicast-s2i
+  spec:
+
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: openresty-base-image
+  spec:
+    tags:
+    - from:
+        kind: DockerImage
+        name: ${BASE_IMAGE}
+      importPolicy:
+        scheduled: true
+      name: latest
+
+
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    name: apicast-s2i-builder
+  spec:
+    successfulBuildsHistoryLimit: 1
+    failedBuildsHistoryLimit: 1
+    nodeSelector: null
+    output:
+      to:
+        kind: ImageStreamTag
+        name: apicast-s2i:builder
+    postCommit: {}
+    resources: {}
+    runPolicy: Serial
+    source:
+      git:
+        uri: "${GIT_REPO}"
+        ref: "${GIT_REF}"
+      type: Git
+    strategy:
+      dockerStrategy:
+        dockerfilePath: Dockerfile
+        from:
+          kind: ImageStreamTag
+          name: openresty-base-image:latest
+      type: Docker
+    triggers:
+    - type: ConfigChange
+    - type: ImageChange
+
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    name: apicast-s2i-runtime
+  spec:
+    successfulBuildsHistoryLimit: 1
+    failedBuildsHistoryLimit: 1
+    nodeSelector: null
+    output:
+      to:
+        kind: ImageStreamTag
+        name: apicast-s2i:runtime
+    postCommit: {}
+    resources: {}
+    runPolicy: Serial
+    source:
+      git:
+        uri: "${GIT_REPO}"
+        ref: "${GIT_REF}"
+      type: Git
+    strategy:
+      dockerStrategy:
+        dockerfilePath: Dockerfile.runtime
+        from:
+          kind: ImageStreamTag
+          name: openresty-base-image:latest
+      type: Docker
+    triggers:
+    - type: ConfigChange
+    - type: ImageChange


### PR DESCRIPTION
Hi team, 

Here is an OpenShift template to build the two S2I images (builder and runtime) from within OpenShift. 

It should help people that begin with Apicast builds to build their own builder and runtime images (for instance, if they need to install additional software on either builder or the runtime image). 

Regards,
Nicolas

 